### PR TITLE
Reduce image size by using CPU-only torch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-﻿fastapi
+fastapi
 uvicorn
 openai-whisper
 python-multipart
+torch==2.7.1+cpu
+--extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary
- shrink dependencies by installing CPU build of torch

## Testing
- `python -m py_compile main.py`
- `pip install --dry-run -r requirements.txt` *(fails: cannot connect to proxy for download.pytorch.org)*

------
https://chatgpt.com/codex/tasks/task_e_68894a68324c8321b62d62eb76416561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyTorch dependency to version 2.7.1 with CPU-only support.
  * Added an additional package index for PyTorch CPU wheels.
  * Minor cleanup in the requirements list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->