### PR TITLE
Fix server port and add health endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+@app.get("/")
+async def health_check():
+    return {"status": "ok"}
+
 model = whisper.load_model("base")
 
 @app.post("/transcribe")
@@ -48,4 +52,5 @@ async def transcribe(file: UploadFile = File(...)):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=7860)
+    port = int(os.getenv("PORT", 8080))
+    uvicorn.run("main:app", host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- add a health check endpoint at `/`
- allow server port to be overridden with the `PORT` environment variable

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt` *(fails: `Tunnel connection failed: 403 Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_6889510b7adc8321a86554a72600d8ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint at the root path ("/") that returns a status message.

* **Chores**
  * Updated server to use the port specified by the environment variable `PORT`, defaulting to 8080 if not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->